### PR TITLE
Add support for PLDM file table

### DIFF
--- a/libpldm/file_io.c
+++ b/libpldm/file_io.c
@@ -50,3 +50,60 @@ int encode_rw_file_memory_resp(uint8_t instance_id, uint8_t command,
 
 	return PLDM_SUCCESS;
 }
+
+int decode_get_file_table_req(const struct pldm_msg_payload *msg,
+			      uint32_t *transfer_handle,
+			      uint8_t *transfer_opflag, uint8_t *table_type)
+{
+	if (msg == NULL || transfer_handle == NULL || transfer_opflag == NULL ||
+	    table_type == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	if (msg->payload_length != PLDM_GET_FILE_TABLE_REQ_BYTES) {
+		return PLDM_ERROR_INVALID_LENGTH;
+	}
+
+	const uint8_t *start = msg->payload;
+	*transfer_handle = le32toh(*((uint32_t *)start));
+	*transfer_opflag = *(start + sizeof(*transfer_handle));
+	*table_type =
+	    *(start + sizeof(*transfer_handle) + sizeof(*transfer_opflag));
+
+	return PLDM_SUCCESS;
+}
+
+int encode_get_file_table_resp(uint8_t instance_id, uint8_t completion_code,
+			       uint32_t next_transfer_handle,
+			       uint8_t transfer_flag, const uint8_t *table_data,
+			       size_t table_size, struct pldm_msg *msg)
+{
+	struct pldm_header_info header = {0};
+	int rc = PLDM_SUCCESS;
+
+	header.msg_type = PLDM_RESPONSE;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_FILE_IO;
+	header.command = PLDM_GET_FILE_TABLE;
+
+	if ((rc = pack_pldm_header(&header, &(msg->hdr))) > PLDM_SUCCESS) {
+		return rc;
+	}
+
+	msg->body.payload[0] = completion_code;
+
+	if (msg->body.payload[0] == PLDM_SUCCESS) {
+		uint8_t *dst = msg->body.payload + sizeof(completion_code);
+		next_transfer_handle = htole32(next_transfer_handle);
+		memcpy(dst, &next_transfer_handle,
+		       sizeof(next_transfer_handle));
+		dst += sizeof(next_transfer_handle);
+
+		memcpy(dst, &transfer_flag, sizeof(transfer_flag));
+		dst += sizeof(transfer_flag);
+
+		memcpy(dst, table_data, table_size);
+	}
+
+	return PLDM_SUCCESS;
+}

--- a/libpldm/file_io.h
+++ b/libpldm/file_io.h
@@ -13,6 +13,7 @@ extern "C" {
 /** @brief PLDM Commands in FileIO type
  */
 enum pldm_fileio_commands {
+	PLDM_GET_FILE_TABLE = 0x1,
 	PLDM_READ_FILE_INTO_MEMORY = 0x6,
 	PLDM_WRITE_FILE_FROM_MEMORY = 0x7,
 };
@@ -24,10 +25,20 @@ enum pldm_fileio_completion_codes {
 	PLDM_DATA_OUT_OF_RANGE = 0x81,
 	PLDM_INVALID_READ_LENGTH = 0x82,
 	PLDM_INVALID_WRITE_LENGTH = 0x83,
+	PLDM_FILE_TABLE_UNAVAILABLE = 0x84,
+	PLDM_INVALID_FILE_TABLE_TYPE = 0x85,
+};
+
+/** @brief PLDM File I/O table types
+ */
+enum pldm_fileio_table_type {
+	PLDM_FILE_ATTRIBUTE_TABLE = 0,
+	PLDM_OEM_FILE_ATTRIBUTE_TABLE = 1,
 };
 
 #define PLDM_RW_FILE_MEM_REQ_BYTES 20
 #define PLDM_RW_FILE_MEM_RESP_BYTES 5
+#define PLDM_GET_FILE_TABLE_REQ_BYTES 6
 
 /** @brief Decode ReadFileIntoMemory and WriteFileFromMemory commands request
  *
@@ -58,6 +69,36 @@ int decode_rw_file_memory_req(const struct pldm_msg_payload *msg,
 int encode_rw_file_memory_resp(uint8_t instance_id, uint8_t command,
 			       uint8_t completion_code, uint32_t length,
 			       struct pldm_msg *msg);
+
+/** @brief Decode GetFileTable command request data
+ *
+ *  @param[in] msg - Request message payload
+ *  @param[out] trasnfer_handle - the handle of data
+ *  @param[out] transfer_opflag - Transfer operation flag
+ *  @param[out] table_type - the type of file table
+ *  @return pldm_completion_codes
+ */
+int decode_get_file_table_req(const struct pldm_msg_payload *msg,
+			      uint32_t *transfer_handle,
+			      uint8_t *transfer_opflag, uint8_t *table_type);
+
+/** @brief Create a PLDM response for GetFileTable command
+ *
+ *  @param[in] instance_id - Message's instance id
+ *  @param[in] completion_code - PLDM completion code
+ *  @param[in] next_transfer_handle - Handle to identify next portion of
+ *              data transfer
+ *  @param[in] transfer_flag - Represents the part of transfer
+ *  @param[in] table_data - pointer to file table data
+ *  @param[in] table_size - file table size
+ *  @param[in,out] msg - Message will be written to this
+ *  @return pldm_completion_codes
+ *  @note  Caller is responsible for memory alloc and dealloc of param 'msg'
+ */
+int encode_get_file_table_resp(uint8_t instance_id, uint8_t completion_code,
+			       uint32_t next_transfer_handle,
+			       uint8_t transfer_flag, const uint8_t *table_data,
+			       size_t table_size, struct pldm_msg *msg);
 
 #ifdef __cplusplus
 }

--- a/libpldmresponder/Makefile.am
+++ b/libpldmresponder/Makefile.am
@@ -5,7 +5,8 @@ libpldmresponder_la_SOURCES = \
 	utils.cpp \
 	bios.cpp \
 	file_io.cpp \
-	platform.cpp
+	platform.cpp \
+        file_table.cpp
 
 libpldmresponder_la_LIBADD = \
 	../libpldm/libpldm.la \

--- a/libpldmresponder/file_io.cpp
+++ b/libpldmresponder/file_io.cpp
@@ -1,5 +1,6 @@
 #include "file_io.hpp"
 
+#include "file_table.hpp"
 #include "registration.hpp"
 
 #include <fcntl.h>
@@ -29,6 +30,8 @@ void registerHandlers()
                     std::move(readFileIntoMemory));
     registerHandler(PLDM_FILE_IO, PLDM_WRITE_FILE_FROM_MEMORY,
                     std::move(writeFileFromMemory));
+    registerHandler(PLDM_FILE_IO, PLDM_GET_FILE_TABLE,
+                    std::move(getFileAttrTable));
 }
 
 namespace fs = std::filesystem;
@@ -146,53 +149,46 @@ void readFileIntoMemory(const pldm_msg_payload* request, pldm_msg* response)
 
     decode_rw_file_memory_req(request, &fileHandle, &offset, &length, &address);
 
-    if (length % dma::minSize)
-    {
-        log<level::ERR>("Readlength is not a multiple of 16");
-        encode_rw_file_memory_resp(0, PLDM_READ_FILE_INTO_MEMORY,
-                                   PLDM_INVALID_READ_LENGTH, 0, response);
-        return;
-    }
+    using namespace pldm::filetable;
+    auto& table = getFileTable(FILE_TABLE_JSON);
+    auto [rc, value] = table.getFileEntry(fileHandle);
 
-    std::string readFilePath;
-    if (fileHandle == 0)
+    if (!rc || !fs::exists(value.fsPath))
     {
-        readFilePath = "/var/lib/pldm/PHYP-NVRAM";
-    }
-    else if (fileHandle == 1)
-    {
-        readFilePath = "/var/lib/pldm/PHYP-NVRAM-CKSUM";
-    }
-    else
-    {
-        log<level::ERR>("Invalid file handle");
-        encode_rw_file_memory_resp(0, PLDM_READ_FILE_INTO_MEMORY,
-                                   PLDM_INVALID_FILE_HANDLE, 0, response);
-    }
-    fs::path path{readFilePath};
-
-    if (!fs::exists(path))
-    {
-
-        log<level::ERR>("File does not exist");
+        log<level::ERR>("File does not exist", entry("HANDLE=%d", fileHandle));
         encode_rw_file_memory_resp(0, PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, response);
         return;
     }
 
-    auto fileSize = fs::file_size(path);
-    if (offset + length > fileSize)
+    auto fileSize = fs::file_size(value.fsPath);
+    if (offset >= fileSize)
     {
-        log<level::ERR>("Data out of range");
+        log<level::ERR>("Offset exceeds file size", entry("OFFSET=%d", offset),
+                        entry("FILE_SIZE=%d", fileSize));
         encode_rw_file_memory_resp(0, PLDM_READ_FILE_INTO_MEMORY,
                                    PLDM_DATA_OUT_OF_RANGE, 0, response);
         return;
     }
 
+    if (offset + length > fileSize)
+    {
+        length = fileSize - offset;
+    }
+
+    if (length % dma::minSize)
+    {
+        log<level::ERR>("Read length is not a multiple of DMA minSize",
+                        entry("LENGTH=%d", length));
+        encode_rw_file_memory_resp(0, PLDM_READ_FILE_INTO_MEMORY,
+                                   PLDM_INVALID_READ_LENGTH, 0, response);
+        return;
+    }
+
     using namespace dma;
     DMA intf;
-    transferAll<DMA>(&intf, PLDM_READ_FILE_INTO_MEMORY, path, offset, length,
-                     address, true, response);
+    transferAll<DMA>(&intf, PLDM_READ_FILE_INTO_MEMORY, value.fsPath, offset,
+                     length, address, true, response);
 }
 
 void writeFileFromMemory(const pldm_msg_payload* request, pldm_msg* response)
@@ -214,41 +210,77 @@ void writeFileFromMemory(const pldm_msg_payload* request, pldm_msg* response)
 
     if (length % dma::minSize)
     {
-        log<level::ERR>("Writelength is not a multiple of 16");
+        log<level::ERR>("Write length is not a multiple of DMA minSize",
+                        entry("LENGTH=%d", length));
         encode_rw_file_memory_resp(0, PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_INVALID_WRITE_LENGTH, 0, response);
         return;
     }
 
-    std::string readFilePath;
-    if (fileHandle == 0)
-    {
-        readFilePath = "/var/lib/pldm/PHYP-NVRAM";
-    }
-    else if (fileHandle == 1)
-    {
-        readFilePath = "/var/lib/pldm/PHYP-NVRAM-CKSUM";
-    }
-    else
-    {
-        log<level::ERR>("Invalid file handle");
-        encode_rw_file_memory_resp(0, PLDM_WRITE_FILE_FROM_MEMORY,
-                                   PLDM_INVALID_FILE_HANDLE, 0, response);
-    }
-    fs::path path{readFilePath};
+    using namespace pldm::filetable;
+    auto& table = getFileTable(FILE_TABLE_JSON);
+    auto [rc, value] = table.getFileEntry(fileHandle);
 
-    if (!fs::exists(path))
+    if (!rc || !fs::exists(value.fsPath))
     {
-        log<level::ERR>("File does not exist");
+        log<level::ERR>("File does not exist", entry("HANDLE=%d", fileHandle));
         encode_rw_file_memory_resp(0, PLDM_WRITE_FILE_FROM_MEMORY,
                                    PLDM_INVALID_FILE_HANDLE, 0, response);
         return;
     }
 
+    auto fileSize = fs::file_size(value.fsPath);
+    if (offset >= fileSize)
+    {
+        log<level::ERR>("Offset exceeds file size", entry("OFFSET=%d", offset),
+                        entry("FILE_SIZE=%d", fileSize));
+        encode_rw_file_memory_resp(0, PLDM_WRITE_FILE_FROM_MEMORY,
+                                   PLDM_DATA_OUT_OF_RANGE, 0, response);
+        return;
+    }
+
     using namespace dma;
     DMA intf;
-    transferAll<DMA>(&intf, PLDM_WRITE_FILE_FROM_MEMORY, path, offset, length,
-                     address, false, response);
+    transferAll<DMA>(&intf, PLDM_WRITE_FILE_FROM_MEMORY, value.fsPath, offset,
+                     length, address, false, response);
+}
+
+void getFileAttrTable(const pldm_msg_payload* request, pldm_msg* response)
+{
+    uint32_t transferHandle = 0;
+    uint8_t transferFlag = 0;
+    uint8_t tableType = 0;
+
+    if (request->payload_length != PLDM_GET_FILE_TABLE_REQ_BYTES)
+    {
+        encode_get_file_table_resp(0, PLDM_ERROR_INVALID_LENGTH, 0, 0, nullptr,
+                                   0, response);
+        return;
+    }
+
+    decode_get_file_table_req(request, &transferHandle, &transferFlag,
+                              &tableType);
+
+    if (tableType != PLDM_FILE_ATTRIBUTE_TABLE)
+    {
+        encode_get_file_table_resp(0, PLDM_INVALID_FILE_TABLE_TYPE, 0, 0,
+                                   nullptr, 0, response);
+        return;
+    }
+
+    using namespace pldm::filetable;
+    auto& table = getFileTable(FILE_TABLE_JSON);
+    auto attrTable = table.getFileAttrTable();
+
+    if (attrTable.empty())
+    {
+        encode_get_file_table_resp(0, PLDM_FILE_TABLE_UNAVAILABLE, 0, 0,
+                                   nullptr, 0, response);
+        return;
+    }
+
+    encode_get_file_table_resp(0, PLDM_SUCCESS, 0, PLDM_START_AND_END,
+                               attrTable.data(), attrTable.size(), response);
 }
 
 } // namespace fileio

--- a/libpldmresponder/file_io.hpp
+++ b/libpldmresponder/file_io.hpp
@@ -161,6 +161,13 @@ void readFileIntoMemory(const pldm_msg_payload* request, pldm_msg* response);
  */
 void writeFileFromMemory(const pldm_msg_payload* request, pldm_msg* response);
 
+/** @brief Handler for GetFileTable command
+ *
+ *  @param[in] request - request message payload
+ *  @param[out] response - response message location
+ */
+void getFileAttrTable(const pldm_msg_payload* request, pldm_msg* response);
+
 } // namespace fileio
 } // namespace responder
 } // namespace pldm

--- a/libpldmresponder/file_table.cpp
+++ b/libpldmresponder/file_table.cpp
@@ -1,0 +1,140 @@
+#include "file_table.hpp"
+
+#include <boost/crc.hpp>
+#include <experimental/filesystem>
+#include <fstream>
+#include <iostream>
+#include <phosphor-logging/log.hpp>
+
+namespace pldm
+{
+
+namespace filetable
+{
+
+using namespace phosphor::logging;
+
+FileTable::FileTable(const std::string& fileTablePath)
+{
+    std::ifstream jsonFile(fileTablePath);
+    if (!jsonFile.is_open())
+    {
+        log<level::ERR>("File table config file does not exist",
+                        entry("FILE=%s", fileTablePath.c_str()));
+        return;
+    }
+
+    auto data = Json::parse(jsonFile, nullptr, false);
+    if (data.is_discarded())
+    {
+        log<level::ERR>("Parsing config file failed");
+        return;
+    }
+
+    uint16_t fileNameLength = 0;
+    uint32_t fileSize = 0;
+    uint32_t traits = 0;
+    size_t tableSize = 0;
+    auto iter = fileTable.begin();
+
+    // Iterate through each JSON object in the config file
+    for (const auto& record : data)
+    {
+        std::string filepath = record.value(path, "");
+        traits = static_cast<uint32_t>(record.value(fileTraits, 0));
+
+        fs::path fsPath(filepath);
+        if (!fs::exists(fsPath))
+        {
+            continue;
+        }
+
+        fileNameLength =
+            static_cast<uint16_t>(fsPath.filename().string().size());
+        fileSize = static_cast<uint32_t>(fs::file_size(fsPath));
+        tableSize = fileTable.size();
+
+        fileTable.resize(tableSize + sizeof(handle) + sizeof(fileNameLength) +
+                         fileNameLength + sizeof(fileSize) + sizeof(traits));
+        iter = fileTable.begin() + tableSize;
+
+        // Populate the file table with the contents of the JSON entry
+        std::copy_n(reinterpret_cast<uint8_t*>(&handle), sizeof(handle), iter);
+        std::advance(iter, sizeof(handle));
+
+        std::copy_n(reinterpret_cast<uint8_t*>(&fileNameLength),
+                    sizeof(fileNameLength), iter);
+        std::advance(iter, sizeof(fileNameLength));
+
+        std::copy_n(reinterpret_cast<const uint8_t*>(fsPath.filename().c_str()),
+                    fileNameLength, iter);
+        std::advance(iter, fileNameLength);
+
+        std::copy_n(reinterpret_cast<uint8_t*>(&fileSize), sizeof(fileSize),
+                    iter);
+        std::advance(iter, sizeof(fileSize));
+
+        std::copy_n(reinterpret_cast<uint8_t*>(&traits), sizeof(traits), iter);
+        std::advance(iter, sizeof(traits));
+
+        // Create the file entry for the JSON entry
+        FileEntry entry{};
+        entry.handle = handle;
+        entry.fsPath = std::move(fsPath);
+        entry.traits = traits;
+
+        // Insert the file entries in the map
+        tableEntries.emplace(handle, std::move(entry));
+        handle++;
+    }
+
+    tableSize = fileTable.size();
+    // Add pad bytes
+    if ((tableSize % 4) != 0)
+    {
+        padCount = 4 - (tableSize % 4);
+        fileTable.resize(tableSize + padCount, 0);
+    }
+
+    // Calculate the checksum
+    boost::crc_32_type result;
+    result.process_bytes(fileTable.data(), fileTable.size());
+    checkSum = result.checksum();
+}
+
+std::vector<uint8_t> FileTable::getFileAttrTable() const
+{
+    std::vector<uint8_t> table(fileTable);
+    table.resize(fileTable.size() + sizeof(checkSum));
+    auto iter = table.begin() + fileTable.size();
+    std::copy_n(reinterpret_cast<const uint8_t*>(&checkSum), sizeof(checkSum),
+                iter);
+    return table;
+}
+
+std::tuple<bool, FileEntry> FileTable::getFileEntry(Handle handle) const
+{
+    FileEntry entry{};
+    auto result = tableEntries.find(handle);
+    if (result != tableEntries.end())
+    {
+        return std::make_tuple(true, result->second);
+    }
+    else
+    {
+        return std::make_tuple(false, entry);
+    }
+}
+
+FileTable& getFileTable(const std::string& fileTablePath)
+{
+    static FileTable table;
+    if (table.empty())
+    {
+        table = std::move(FileTable(fileTablePath));
+    }
+    return table;
+}
+
+} // namespace filetable
+} // namespace pldm

--- a/libpldmresponder/file_table.hpp
+++ b/libpldmresponder/file_table.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <filesystem>
+#include <nlohmann/json.hpp>
+#include <vector>
+
+#include "libpldm/base.h"
+
+namespace pldm
+{
+
+namespace filetable
+{
+
+namespace fs = std::filesystem;
+using Handle = uint32_t;
+using Json = nlohmann::json;
+
+static constexpr auto path = "path";
+static constexpr auto fileTraits = "file_traits";
+static constexpr auto FILE_TABLE_JSON = "/var/lib/pldm/fileTable.json";
+
+/** @struct FileEntry
+ *
+ *  Data structure for storing information regarding the files supported by
+ *  PLDM File I/O. The file handle is used to uniquely identify the file. The
+ *  traits provide information whether the file is Read only, Read/Write and
+ *  preserved across firmware upgrades.
+ */
+struct FileEntry
+{
+    uint32_t handle; //!< File handle
+    fs::path fsPath; //!< File path
+    uint32_t traits; //!< File traits
+};
+
+/** @class FileTable
+ *
+ *  FileTable class encapsulates the data related to files supported by PLDM
+ *  File I/O and provides interfaces to lookup files information based on the
+ *  file handle and extract the file attribute table. The file attribute table
+ *  comprises of metadata for files. Metadata includes the file handle, file
+ *  name, current file size and file traits.
+ */
+class FileTable
+{
+  public:
+    FileTable(const std::string& fileTablePath);
+    FileTable() = default;
+    ~FileTable() = default;
+    FileTable(const FileTable&) = default;
+    FileTable& operator=(const FileTable&) = default;
+    FileTable(FileTable&&) = default;
+    FileTable& operator=(FileTable&&) = default;
+
+    /** @brief Get the file attribute table
+     *
+     * @return contents of the file attribute table
+     */
+    std::vector<uint8_t> getFileAttrTable() const;
+
+    /** @brief Return the FileEntry if the file handle is valid
+     *
+     * @param[in] handle - file handle
+     *
+     * @return a tuple, a bool indicating whether there is an entry for the
+     *         file handle and the FileEntry if the bool is true.
+     */
+    std::tuple<bool, FileEntry> getFileEntry(Handle handle) const;
+
+    /** @brief Check is file attribute table is empty
+     *
+     * @return bool - true if file attribute table is empty, false otherwise.
+     */
+    bool empty() const
+    {
+        return fileTable.empty();
+    }
+
+    /** @brief Clear the file table contents
+     *
+     */
+    void clear()
+    {
+        tableEntries.clear();
+        fileTable.clear();
+        padCount = 0;
+        checkSum = 0;
+        handle = 0;
+    }
+
+  private:
+    /** @brief handle to FileEntry mappings for lookups based on file handle */
+    std::unordered_map<Handle, FileEntry> tableEntries;
+
+    /** @brief file attribute table including the pad bytes, except the checksum
+     */
+    std::vector<uint8_t> fileTable;
+
+    /** @brief the pad count of the file attribute table, the number of pad
+     * bytes is between 0 and 3 */
+    uint8_t padCount = 0;
+
+    /** @brief the checksum of the file attribute table */
+    uint32_t checkSum = 0;
+
+    /** @brief file handle value */
+    Handle handle = 0;
+};
+
+/** @brief Build the file attribute table if not already built using the
+ *         file table config.
+ *
+ *  @param[in] fileTablePath - path of the file table config
+ *
+ *  @return FileTable& - Reference to instance of file table
+ */
+
+FileTable& getFileTable(const std::string& fileTablePath);
+
+} // namespace filetable
+} // namespace pldm

--- a/mctp-lpc-setup.cpp
+++ b/mctp-lpc-setup.cpp
@@ -22,7 +22,9 @@ std::map<uint8_t, size_t> commandToRespSize = {
     {PLDM_SET_STATE_EFFECTER_STATES, 1},
     {PLDM_READ_FILE_INTO_MEMORY, PLDM_RW_FILE_MEM_RESP_BYTES},
     {PLDM_WRITE_FILE_FROM_MEMORY, PLDM_RW_FILE_MEM_RESP_BYTES},
-    {PLDM_GET_DATE_TIME, 8}
+    {PLDM_GET_DATE_TIME, 8},
+    // Hardcoded for the output of PHYP-NVRAM and PHYP-NVRAM-CKSUM
+    {PLDM_GET_FILE_TABLE, 66},
 };
 
 namespace mctp_lpc


### PR DESCRIPTION
This commit adds support for file table, implement getfiletable command.
Refactor ReadFileIntoMemory and WriteFileFromMemory to look up file path
from the file table based on the file handle index.

Signed-off-by: Tom Joseph <tomjoseph@in.ibm.com>